### PR TITLE
Add Cluster Autoscaler taint handling

### DIFF
--- a/internal/kubernetes/drainSchedule.go
+++ b/internal/kubernetes/drainSchedule.go
@@ -67,7 +67,7 @@ func (d *DrainSchedules) HasSchedule(name string) (has, failed bool) {
 	if !ok {
 		return false, false
 	}
-	d.logger.Info("HasSchedule", zap.Time("when", sched.when), zap.Time("finish", sched.finish), zap.Bool("isFailed", sched.isFailed()))
+	d.logger.Info("HasSchedule", zap.String("schedule", name), zap.Time("when", sched.when), zap.Time("finish", sched.finish), zap.Bool("isFailed", sched.isFailed()))
 	return true, sched.isFailed()
 }
 
@@ -77,7 +77,7 @@ func (d *DrainSchedules) DeleteSchedule(name string) {
 	if s, ok := d.schedules[name]; ok {
 		s.timer.Stop()
 	} else {
-		d.logger.Error("Failed schedule deletion", zap.String("key", name))
+		d.logger.Error("Failed schedule deletion", zap.String("schedule", name))
 	}
 	delete(d.schedules, name)
 }

--- a/internal/kubernetes/drainSchedule.go
+++ b/internal/kubernetes/drainSchedule.go
@@ -55,7 +55,7 @@ func (d *DrainSchedules) IsScheduledByOldEvent(name string, transitionTime time.
 	defer d.Unlock()
 	sched, ok := d.schedules[name]
 	if !ok {
-		return true
+		return false
 	}
 	return sched.when.Before(transitionTime) && !sched.isFailed() && !sched.finish.IsZero()
 }
@@ -67,7 +67,7 @@ func (d *DrainSchedules) HasSchedule(name string) (has, failed bool) {
 	if !ok {
 		return false, false
 	}
-	d.logger.Info("HasSchedule", zap.String("schedule", name), zap.Time("when", sched.when), zap.Time("finish", sched.finish), zap.Bool("isFailed", sched.isFailed()))
+	d.logger.Info("HasSchedule", zap.String("node", name), zap.Time("when", sched.when), zap.Time("finish", sched.finish), zap.Bool("isFailed", sched.isFailed()))
 	return true, sched.isFailed()
 }
 
@@ -76,10 +76,10 @@ func (d *DrainSchedules) DeleteSchedule(name string) {
 	defer d.Unlock()
 	if s, ok := d.schedules[name]; ok {
 		s.timer.Stop()
+		delete(d.schedules, name)
 	} else {
-		d.logger.Error("Failed schedule deletion", zap.String("schedule", name))
+		d.logger.Error("Failed to schedule deletion", zap.String("node", name))
 	}
-	delete(d.schedules, name)
 }
 
 func (d *DrainSchedules) WhenNextSchedule() time.Time {

--- a/internal/kubernetes/drainer.go
+++ b/internal/kubernetes/drainer.go
@@ -349,10 +349,10 @@ func (d *APICordonDrainer) getPods(node string) ([]core.Pod, error) {
 			return nil, errors.Wrap(err, "cannot filter pods")
 		}
 		if passes {
-			d.l.Info("Pod added to list", zap.String("PodName", p.Name))
+			d.l.Info("Pod added to list", zap.String("node", node), zap.String("PodName", p.Name))
 			include = append(include, p)
 		} else {
-			d.l.Info("Pod ignored list", zap.String("PodName", p.Name))
+			d.l.Info("Pod ignored list", zap.String("node", node), zap.String("PodName", p.Name))
 		}
 	}
 	return include, nil

--- a/internal/kubernetes/eventhandler.go
+++ b/internal/kubernetes/eventhandler.go
@@ -149,6 +149,7 @@ func (h *DrainingResourceEventHandler) OnDelete(obj interface{}) {
 			return
 		}
 		h.drainScheduler.DeleteSchedule(d.Key)
+		return
 	}
 	h.drainScheduler.DeleteSchedule(n.GetName())
 }
@@ -163,7 +164,7 @@ func (h *DrainingResourceEventHandler) HandleNode(n *core.Node) {
 
 	nodeTaints := n.Spec.Taints
 	if len(nodeTaints) > 0 && taintExists(nodeTaints, &autoscalerTaint) {
-		h.logger.Info("Node is being scaled down by Cluster Autoscaler, skipping.")
+		h.logger.Info("Node is being scaled down by cluster-autoscaler, skipping...", zap.String("node", n.GetName()))
 		return
 	}
 
@@ -195,7 +196,7 @@ func (h *DrainingResourceEventHandler) HandleNode(n *core.Node) {
 			}
 		}
 		if isScheduledByOldEvent {
-			h.logger.Info("Already scheduled by an old event, scheduling new drain.", zap.Bool("isValid", isScheduledByOldEvent))
+			h.logger.Info("Already scheduled by an old event, scheduling new drain.", zap.String("node", n.GetName()), zap.Bool("isValid", isScheduledByOldEvent))
 			h.drainScheduler.DeleteSchedule(n.GetName())
 			h.scheduleDrain(n)
 			return


### PR DESCRIPTION
## Description

This PR modifies the `HandleNode` function of `draino` to honor the taints (`ToBeDeletedByClusterAutoscaler=(timestamp):NoSchedule`) set by Cluster Autoscaler, to avoid a race condition where the Cluster Autoscaler and `draino` would both try to drain the node at the same time.