### PR TITLE
Delete prior schedule if tainted by CAS/Karpenter

### DIFF
--- a/internal/kubernetes/drainSchedule.go
+++ b/internal/kubernetes/drainSchedule.go
@@ -78,7 +78,7 @@ func (d *DrainSchedules) DeleteSchedule(name string) {
 		s.timer.Stop()
 		delete(d.schedules, name)
 	} else {
-		d.logger.Error("Failed to schedule deletion", zap.String("node", name))
+		d.logger.Warn("Entry not found in deletion schedule", zap.String("node", name))
 	}
 }
 

--- a/internal/kubernetes/eventhandler.go
+++ b/internal/kubernetes/eventhandler.go
@@ -171,6 +171,7 @@ func (h *DrainingResourceEventHandler) HandleNode(n *core.Node) {
 		// Delete prior scheduled draining if it exists as its draininng now being managed by Karpenter/CAS
 		preHasSchedule, _ := h.drainScheduler.HasSchedule(n.GetName())
 		if preHasSchedule {
+			h.logger.Info("Node was previously scheduled to be drained by is now being scaled down by cluster-autoscaler/karpenter, removing prior schedule.", zap.String("node", n.GetName()))
 			h.drainScheduler.DeleteSchedule(n.GetName())
 		}
 		h.logger.Info("Node is being scaled down by cluster-autoscaler/karpenter, skipping.", zap.String("node", n.GetName()))

--- a/internal/kubernetes/eventhandler.go
+++ b/internal/kubernetes/eventhandler.go
@@ -168,6 +168,11 @@ func (h *DrainingResourceEventHandler) HandleNode(n *core.Node) {
 
 	nodeTaints := n.Spec.Taints
 	if len(nodeTaints) > 0 && (taintExists(nodeTaints, &autoscalerTaint) || taintExists(nodeTaints, &karpenterTaint)) {
+		// Delete prior scheduled draining if it exists as its draininng now being managed by Karpenter/CAS
+		preHasSchedule, _ := h.drainScheduler.HasSchedule(n.GetName())
+		if preHasSchedule {
+			h.drainScheduler.DeleteSchedule(n.GetName())
+		}
 		h.logger.Info("Node is being scaled down by cluster-autoscaler/karpenter, skipping.", zap.String("node", n.GetName()))
 		return
 	}

--- a/internal/kubernetes/eventhandler.go
+++ b/internal/kubernetes/eventhandler.go
@@ -168,7 +168,7 @@ func (h *DrainingResourceEventHandler) HandleNode(n *core.Node) {
 
 	nodeTaints := n.Spec.Taints
 	if len(nodeTaints) > 0 && (taintExists(nodeTaints, &autoscalerTaint) || taintExists(nodeTaints, &karpenterTaint)) {
-		// Delete prior scheduled draining if it exists as its draininng now being managed by Karpenter/CAS
+		// Delete prior scheduled draining if it exists as its draining now being managed by Karpenter/CAS
 		preHasSchedule, _ := h.drainScheduler.HasSchedule(n.GetName())
 		if preHasSchedule {
 			h.logger.Info("Node was previously scheduled to be drained by is now being scaled down by cluster-autoscaler/karpenter, removing prior schedule.", zap.String("node", n.GetName()))


### PR DESCRIPTION
## Description

Remove existing scheduled drain if the node was previously designated to be drained but now is tainted by CAS/Karpenter to be drained by them. Should prevent errors such:

```
{"level":"error","ts":1708462082.7040603,"caller":"kubernetes/drainSchedule.go:81","msg":"Failed to schedule deletion","node":"ip-10-26-209-29.us-west-2.compute.internal","stacktrace":"github.com/planetlabs/draino/internal/kubernetes.(*DrainSchedules).DeleteSchedule\n\t/go/src/github.com/planetlabs/draino/internal/kubernetes/drainSchedule.go:81\ngithub.com/planetlabs/draino/internal/kubernetes.(*DrainingResourceEventHandler).OnDelete\n\t/go/src/github.com/planetlabs/draino/internal/kubernetes/eventhandler.go:153\nk8s.io/client-go/tools/cache.FilteringResourceEventHandler.OnDelete\n\t/go/pkg/mod/k8s.io/client-go@v0.29.2/tools/cache/controller.go:326\nk8s.io/client-go/tools/cache.(*processorListener).run.func1\n\t/go/pkg/mod/k8s.io/client-go@v0.29.2/tools/cache/shared_informer.go:977\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/go/pkg/mod/k8s.io/apimachinery@v0.29.2/pkg/util/wait/backoff.go:226\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/go/pkg/mod/k8s.io/apimachinery@v0.29.2/pkg/util/wait/backoff.go:227\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/go/pkg/mod/k8s.io/apimachinery@v0.29.2/pkg/util/wait/backoff.go:204\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/go/pkg/mod/k8s.io/apimachinery@v0.29.2/pkg/util/wait/backoff.go:161\nk8s.io/client-go/tools/cache.(*processorListener).run\n\t/go/pkg/mod/k8s.io/client-go@v0.29.2/tools/cache/shared_informer.go:966\nk8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1\n\t/go/pkg/mod/k8s.io/apimachinery@v0.29.2/pkg/util/wait/wait.go:72"}
```